### PR TITLE
Fix tetromino rotations

### DIFF
--- a/server/Game.js
+++ b/server/Game.js
@@ -1,5 +1,10 @@
 import Player from "./Player.js";
-import { TickRate, VectorDown, VectorLeft, VectorRight } from "./TetrisConsts.js";
+import {
+  TickRate,
+  VectorDown,
+  VectorLeft,
+  VectorRight,
+} from "./TetrisConsts.js";
 import { ActionType } from "../shared/DTOs.js";
 import { scoreStore } from "./server.js";
 import { convertToPlayerScores } from "./ScoreStore.js";

--- a/server/Game.js
+++ b/server/Game.js
@@ -1,6 +1,5 @@
 import Player from "./Player.js";
-import { TICK_RATE } from "./TetrisConfig.js";
-import { VectorDown, VectorLeft, VectorRight } from "./TetrisConsts.js";
+import { TickRate, VectorDown, VectorLeft, VectorRight } from "./TetrisConsts.js";
 import { ActionType } from "../shared/DTOs.js";
 import { scoreStore } from "./server.js";
 import { convertToPlayerScores } from "./ScoreStore.js";
@@ -93,7 +92,7 @@ export default class Game {
       //TODO: since the boards will not necessarily change every tick,
       //TODO: we could skip some broadcasts when no changes are made.
       this.#broadcastState();
-      await new Promise((res) => setTimeout(res, 1000 / TICK_RATE));
+      await new Promise((res) => setTimeout(res, 1000 / TickRate));
     }
 
     //NOTE: A draw can occur when all players game over at the same time.

--- a/server/Game.test.js
+++ b/server/Game.test.js
@@ -1,13 +1,17 @@
 import { expect, expectGridArrayToEqual } from "./expect-extensions.js";
 import { describe, it, vi, beforeEach, afterEach } from "vitest";
 import Game from "./Game.js";
-import { Tetrominoes } from "./TetrisConsts.js";
-import { DROP_RATE } from "./TetrisConfig.js";
+import { DropRate, Tetrominoes } from "./TetrisConsts.js";
 import Grid from "./Grid.js";
-import { ActionType, CellType, RulesetType } from "../shared/DTOs.js";
+import {
+  ActionType,
+  CellType,
+  RulesetType,
+  TetrominoType,
+} from "../shared/DTOs.js";
 import { DefaultGameGridDimensions } from "../shared/Consts.js";
 
-// NOTE ensure the score store does nothing
+//NOTE: ensure the score store does nothing
 vi.mock("./ScoreStore.js", () => {
   return {
     default: class {
@@ -50,7 +54,8 @@ describe("Game", () => {
   it("should start with one tetromino", () => {
     const { game, playerNames } = createTetrisGame();
     const gameData = getAndValidateGameData(game, playerNames[0], playerNames);
-    const expectedGrid = getGridWithTetrominoFromSpawnOrder(0, { x: 4, y: 0 });
+    //NOTE: y is -1 because the I tetromino is spawned at y = -1
+    const expectedGrid = getGridWithTetrominoFromSpawnOrder(0, { x: 4, y: -1 });
     expectGridArrayToEqual(gameData.grid, expectedGrid.array);
   });
 
@@ -58,7 +63,8 @@ describe("Game", () => {
     const { game, playerNames } = createTetrisGame();
     await progressGameByDropCount(1);
     const gameData = getAndValidateGameData(game, playerNames[0], playerNames);
-    const expectedGrid = getGridWithTetrominoFromSpawnOrder(0, { x: 4, y: 1 });
+    //NOTE: y is 0 because the I tetromino is spawned at y = -1
+    const expectedGrid = getGridWithTetrominoFromSpawnOrder(0, { x: 4, y: 0 });
     expectGridArrayToEqual(gameData.grid, expectedGrid.array);
   });
 
@@ -108,7 +114,8 @@ describe("Game", () => {
       DefaultGameGridDimensions.x,
     );
     const gameData = getAndValidateGameData(game, playerNames[0], playerNames);
-    const expectedGrid = getGridWithTetrominoFromSpawnOrder(0, { x: 0, y: 0 });
+    //NOTE: y is -1 because the I tetromino is spawned at y = -1
+    const expectedGrid = getGridWithTetrominoFromSpawnOrder(0, { x: 0, y: -1 });
     expectGridArrayToEqual(gameData.grid, expectedGrid.array);
   });
 
@@ -122,9 +129,10 @@ describe("Game", () => {
     );
     const gameData = getAndValidateGameData(game, playerNames[0], playerNames);
     const firstTetromino = getTetrominoFromSpawnOrder(0);
+    //NOTE: y is -1 because the I tetromino is spawned at y = -1
     const expectedGrid = getGridWithTetrominoFromSpawnOrder(0, {
       x: DefaultGameGridDimensions.x - firstTetromino.cols,
-      y: 0,
+      y: -1,
     });
     expectGridArrayToEqual(gameData.grid, expectedGrid.array);
   });
@@ -141,7 +149,10 @@ describe("Game", () => {
     const firstTetromino = getTetrominoFromSpawnOrder(0);
     const expectedGrid = getGridWithTetrominoFromSpawnOrder(0, {
       x: 4,
-      y: DefaultGameGridDimensions.y - firstTetromino.rows,
+      y:
+        DefaultGameGridDimensions.y -
+        firstTetromino.topMostNonEmptyRow -
+        firstTetromino.height,
     });
     expectGridArrayToEqual(gameData.grid, expectedGrid.array);
   });
@@ -153,7 +164,10 @@ describe("Game", () => {
     const firstTetromino = getTetrominoFromSpawnOrder(0);
     const expectedGrid = getGridWithTetrominoFromSpawnOrder(0, {
       x: 4,
-      y: DefaultGameGridDimensions.y - firstTetromino.rows,
+      y:
+        DefaultGameGridDimensions.y -
+        firstTetromino.topMostNonEmptyRow -
+        firstTetromino.height,
     });
     expectGridArrayToEqual(gameData.grid, expectedGrid.array);
   });
@@ -166,14 +180,14 @@ describe("Game", () => {
       DefaultGameGridDimensions.y,
       DefaultGameGridDimensions.x,
     );
-    expectedGrid1.array[0][4] = CellType.I;
-    expectedGrid1.array[1][4] = CellType.I;
-    expectedGrid1.array[2][4] = CellType.I;
-    expectedGrid1.array[3][4] = CellType.I;
+    expectedGrid1.array[0][6] = CellType.I;
+    expectedGrid1.array[1][6] = CellType.I;
+    expectedGrid1.array[2][6] = CellType.I;
+    expectedGrid1.array[3][6] = CellType.I;
     expectGridArrayToEqual(gameData1.grid, expectedGrid1.array);
     executeActions(game, playerNames, ActionType.Rotate);
     const gameData2 = getAndValidateGameData(game, playerNames[0], playerNames);
-    const expectedGrid2 = getGridWithTetrominoFromSpawnOrder(0, { x: 4, y: 0 });
+    const expectedGrid2 = getGridWithTetrominoFromSpawnOrder(0, { x: 4, y: 1 });
     expectGridArrayToEqual(gameData2.grid, expectedGrid2.array);
   });
 
@@ -191,11 +205,17 @@ describe("Game", () => {
     const gameData = getAndValidateGameData(game, playerNames[0], playerNames);
     const gridWithFirstTetromino = getGridWithTetrominoFromSpawnOrder(0, {
       x: 4,
-      y: DefaultGameGridDimensions.y - getTetrominoFromSpawnOrder(0).rows,
+      y:
+        DefaultGameGridDimensions.y -
+        getTetrominoFromSpawnOrder(0).topMostNonEmptyRow -
+        getTetrominoFromSpawnOrder(0).height,
     });
     const gridWithSecondTetromino = getGridWithTetrominoFromSpawnOrder(1, {
-      x: DefaultGameGridDimensions.x - getTetrominoFromSpawnOrder(1).cols,
-      y: 0,
+      x:
+        DefaultGameGridDimensions.x -
+        getTetrominoFromSpawnOrder(1).leftMostNonEmptyCol -
+        getTetrominoFromSpawnOrder(1).width,
+      y: 1,
     });
     const expectedGrid = Grid.superimposeOnEmptyCells(
       gridWithFirstTetromino,
@@ -282,7 +302,7 @@ function createTetrisGame(playerNames = ["Player1", "Player2"]) {
  * @param {number} dropCount
  */
 async function progressGameByDropCount(dropCount) {
-  await vi.advanceTimersByTimeAsync(DROP_RATE * 1000 * dropCount);
+  await vi.advanceTimersByTimeAsync(DropRate * 1000 * dropCount);
 }
 
 /**
@@ -346,9 +366,8 @@ function getGridWithTetrominoFromSpawnOrder(
  * @param {number} rotationCount
  */
 function getTetrominoFromSpawnOrder(spawnOrderIndex, rotationCount = 0) {
-  const tetromino = Grid.fromArray(
-    Tetrominoes[TetrominoSpawnOrder[spawnOrderIndex]],
-  );
+  const tetrominoType = TetrominoSpawnOrder[spawnOrderIndex];
+  const tetromino = Grid.fromArray(Tetrominoes[tetrominoType]);
 
   for (let i = 0; i < rotationCount; i++) {
     tetromino.array = Grid.fromArray(tetromino.array).rotateClockwise();
@@ -419,7 +438,6 @@ async function makePlayerClearTwoLines(game, playerName) {
   }
 
   executeActions(game, [playerName], ActionType.Rotate);
-  executeActions(game, [playerName], ActionType.MoveRight);
   executeActions(game, [playerName], ActionType.HardDrop);
   await progressGameByDropCount(1);
 }

--- a/server/Grid.js
+++ b/server/Grid.js
@@ -9,6 +9,54 @@ export default class Grid {
     return this.array[0].length;
   }
 
+  get leftMostNonEmptyCol() {
+    for (let x = 0; x < this.cols; x++) {
+      if (this.array.some((row) => row[x] !== CellType.Empty)) {
+        return x;
+      }
+    }
+
+    return -1;
+  }
+
+  get rightMostNonEmptyCol() {
+    for (let x = this.cols - 1; x >= 0; x--) {
+      if (this.array.some((row) => row[x] !== CellType.Empty)) {
+        return x;
+      }
+    }
+
+    return -1;
+  }
+
+  get bottomMostNonEmptyRow() {
+    for (let y = this.rows - 1; y >= 0; y--) {
+      if (this.array[y].some((cell) => cell !== CellType.Empty)) {
+        return y;
+      }
+    }
+
+    return -1;
+  }
+
+  get topMostNonEmptyRow() {
+    for (let y = 0; y < this.rows; y++) {
+      if (this.array[y].some((cell) => cell !== CellType.Empty)) {
+        return y;
+      }
+    }
+
+    return -1;
+  }
+
+  get width() {
+    return this.rightMostNonEmptyCol - this.leftMostNonEmptyCol + 1;
+  }
+
+  get height() {
+    return this.bottomMostNonEmptyRow - this.topMostNonEmptyRow + 1;
+  }
+
   /**
    * @return {import("../shared/DTOs.js").Spectrum}
    */
@@ -267,8 +315,8 @@ export default class Grid {
   static overlapsAtPosition(gridA, gridB, gridBPosition) {
     return gridB.array.some((row, i) =>
       row.some(
-        (cell, j) =>
-          cell !== CellType.Empty &&
+        (cellB, j) =>
+          cellB !== CellType.Empty &&
           gridA.array[i + gridBPosition.y]?.[j + gridBPosition.x] !==
             CellType.Empty,
       ),
@@ -280,10 +328,10 @@ export default class Grid {
    * @param {Grid} gridB
    */
   static overlaps(gridA, gridB) {
-    return gridA.array.some((row, i) =>
+    return gridB.array.some((row, i) =>
       row.some(
-        (cell, j) =>
-          cell !== CellType.Empty && gridB.array[i][j] !== CellType.Empty,
+        (cellB, j) =>
+          cellB !== CellType.Empty && gridA.array[i][j] !== CellType.Empty,
       ),
     );
   }

--- a/server/Grid.test.js
+++ b/server/Grid.test.js
@@ -1,8 +1,8 @@
 import { expect, expectGridArrayToEqual } from "./expect-extensions.js";
 import { describe, it } from "vitest";
 import Grid from "./Grid.js";
-import { CellType, PowerUpCellType } from "../shared/DTOs.js";
-import { bombHoleGrid } from "./TetrisConsts.js";
+import { CellType, PowerUpCellType, TetrominoType } from "../shared/DTOs.js";
+import { bombHoleGrid, Tetrominoes } from "./TetrisConsts.js";
 
 describe("Grid", () => {
   it("should create a grid with the correct dimensions", () => {
@@ -49,7 +49,7 @@ describe("Grid", () => {
     expect(result1).toBe(false);
 
     const grid = Grid.fromRowsCols(20, 10);
-    const tetrominoGridO = createTetrominoGridO();
+    const tetrominoGridO = createTetrominoGrid(TetrominoType.O);
     grid.array[19][2] = CellType.I;
     grid.array[19][3] = CellType.I;
     grid.array[19][4] = CellType.I;
@@ -73,7 +73,7 @@ describe("Grid", () => {
 
     {
       const grid = Grid.fromRowsCols(20, 10);
-      const tetrominoGridO = createTetrominoGridO();
+      const tetrominoGridO = createTetrominoGrid(TetrominoType.O);
       grid.array[19][2] = CellType.I;
       grid.array[19][3] = CellType.I;
       grid.array[19][4] = CellType.I;
@@ -91,7 +91,7 @@ describe("Grid", () => {
       grid.array[17][4] = CellType.I;
       grid.array[18][4] = CellType.I;
       grid.array[19][4] = CellType.I;
-      const tetrominoGridZ = createTetrominoGridZ();
+      const tetrominoGridZ = createTetrominoGrid(TetrominoType.Z);
       const position = { x: 2, y: 16 };
       const overlaps = Grid.overlapsAtPosition(grid, tetrominoGridZ, position);
       expect(overlaps).toBe(true);
@@ -113,7 +113,7 @@ describe("Grid", () => {
 
   it("should superimpose on empty cells and at positions correctly", () => {
     const grid = Grid.fromRowsCols(4, 4);
-    const tetrominoGridJ = createTetrominoGridJ();
+    const tetrominoGridJ = createTetrominoGrid(TetrominoType.J);
     const expected1 = [
       [CellType.Empty, CellType.Empty, CellType.Empty, CellType.Empty],
       [CellType.Empty, CellType.Empty, CellType.Empty, CellType.Empty],
@@ -130,7 +130,7 @@ describe("Grid", () => {
     );
     expectGridArrayToEqual(result1.array, expected1);
 
-    const tetrominoGridZ = createTetrominoGridZ();
+    const tetrominoGridZ = createTetrominoGrid(TetrominoType.Z);
     const expected2 = [
       [CellType.Empty, CellType.Empty, CellType.Empty, CellType.Empty],
       [CellType.Empty, CellType.Z, CellType.Z, CellType.Empty],
@@ -239,20 +239,37 @@ describe("Grid", () => {
   });
 
   it("should rotate clockwise", () => {
-    const grid = Grid.fromArray([
-      [CellType.Empty, CellType.Z, CellType.Empty],
-      [CellType.Empty, CellType.I, CellType.Empty],
+    const tetrominoJ = createTetrominoGrid(TetrominoType.J);
+    const arrayBeforeRotation = tetrominoJ.array;
+
+    let rotated = tetrominoJ.rotateClockwise();
+    const expectedGridRotation90 = Grid.fromArray([
+      [CellType.Empty, CellType.J, CellType.J],
+      [CellType.Empty, CellType.J, CellType.Empty],
       [CellType.Empty, CellType.J, CellType.Empty],
     ]);
-    const gridBeforeRotation = grid;
-    const expectedGrid = Grid.fromArray([
+    expectGridArrayToEqual(rotated, expectedGridRotation90.array);
+
+    expectGridArrayToEqual(tetrominoJ.array, arrayBeforeRotation);
+
+    rotated = Grid.fromArray(rotated).rotateClockwise();
+    const Rotation180 = Grid.fromArray([
       [CellType.Empty, CellType.Empty, CellType.Empty],
-      [CellType.J, CellType.I, CellType.Z],
-      [CellType.Empty, CellType.Empty, CellType.Empty],
+      [CellType.J, CellType.J, CellType.J],
+      [CellType.Empty, CellType.Empty, CellType.J],
     ]);
-    const rotated = grid.rotateClockwise();
-    expect(grid).toEqual(gridBeforeRotation);
-    expectGridArrayToEqual(rotated, expectedGrid.array);
+    expectGridArrayToEqual(rotated, Rotation180.array);
+
+    rotated = Grid.fromArray(rotated).rotateClockwise();
+    const Rotation270 = Grid.fromArray([
+      [CellType.Empty, CellType.J, CellType.Empty],
+      [CellType.Empty, CellType.J, CellType.Empty],
+      [CellType.J, CellType.J, CellType.Empty],
+    ]);
+    expectGridArrayToEqual(rotated, Rotation270.array);
+
+    rotated = Grid.fromArray(rotated).rotateClockwise();
+    expectGridArrayToEqual(rotated, arrayBeforeRotation);
   });
 
   it("should superimpose with override", () => {
@@ -333,23 +350,10 @@ function createSuperimposeGrids() {
   };
 }
 
-function createTetrominoGridO() {
-  return Grid.fromArray([
-    [CellType.O, CellType.O],
-    [CellType.O, CellType.O],
-  ]);
-}
-
-function createTetrominoGridZ() {
-  return Grid.fromArray([
-    [CellType.Z, CellType.Z, CellType.Empty],
-    [CellType.Empty, CellType.Z, CellType.Z],
-  ]);
-}
-
-function createTetrominoGridJ() {
-  return Grid.fromArray([
-    [CellType.J, CellType.Empty, CellType.Empty],
-    [CellType.J, CellType.J, CellType.J],
-  ]);
+/**
+ * @param {TetrominoType} tetrominoType
+ * @returns {Grid}
+ */
+function createTetrominoGrid(tetrominoType) {
+  return Grid.fromArray(Tetrominoes[tetrominoType]);
 }

--- a/server/Piece.js
+++ b/server/Piece.js
@@ -57,10 +57,12 @@ export default class Piece extends Grid {
       x: this.#position.x + direction.x,
       y: this.#position.y + direction.y,
     };
-    const overflowsLeft = movedPosition.x < 0;
+
+    const overflowsLeft = movedPosition.x + this.leftMostNonEmptyCol < 0;
     const overflowsRight =
-      movedPosition.x + this.cols > gameGrid.array[0].length;
-    const overflowsBottom = movedPosition.y + this.rows > gameGrid.array.length;
+      movedPosition.x + this.rightMostNonEmptyCol >= gameGrid.array[0].length;
+    const overflowsBottom =
+      movedPosition.y + this.bottomMostNonEmptyRow >= gameGrid.array.length;
     const overflows = overflowsLeft || overflowsRight || overflowsBottom;
 
     return (

--- a/server/Player.js
+++ b/server/Player.js
@@ -127,10 +127,12 @@ export default class Player {
 
     const kicks = [
       { direction: VectorLeft, strength: 1 },
+      { direction: VectorLeft, strength: 2 },
       { direction: VectorRight, strength: 1 },
+      { direction: VectorRight, strength: 2 },
       { direction: VectorUp, strength: 1 },
       { direction: VectorUp, strength: 2 },
-      { direction: VectorUp, strength: 3 },
+      { direction: VectorDown, strength: 1 },
     ];
 
     for (const { direction, strength } of kicks) {
@@ -272,6 +274,10 @@ export default class Player {
       y: 0,
     };
 
+    if (tetrominoType === TetrominoType.I) {
+      position.y -= 1;
+    }
+
     return new Piece(
       tetrominoType,
       position,
@@ -287,7 +293,7 @@ export default class Player {
   }
 
   #getDropRate() {
-    return this.#gameConfig.heavy ? DROP_RATE * 3 : DROP_RATE;
+    return this.#gameConfig.heavy ? DropRate * 3 : DropRate;
   }
 
   /**

--- a/server/Player.js
+++ b/server/Player.js
@@ -7,9 +7,9 @@ import {
 } from "../shared/DTOs.js";
 import Grid from "./Grid.js";
 import Piece from "./Piece.js";
-import { DROP_RATE } from "./TetrisConfig.js";
 import {
   bombHoleGrid,
+  DropRate,
   VectorDown,
   VectorLeft,
   VectorRight,

--- a/server/TetrisConfig.js
+++ b/server/TetrisConfig.js
@@ -1,2 +1,0 @@
-export const TICK_RATE = 20;
-export const DROP_RATE = 1;

--- a/server/TetrisConsts.js
+++ b/server/TetrisConsts.js
@@ -1,6 +1,9 @@
 import Grid from "./Grid.js";
 import { CellType, TetrominoType } from "../shared/DTOs.js";
 
+export const TickRate = 20;
+export const DropRate = 1;
+
 export const Tetrominoes = deepFreeze({
   [TetrominoType.I]: [[CellType.I, CellType.I, CellType.I, CellType.I]],
   [TetrominoType.O]: [

--- a/server/TetrisConsts.js
+++ b/server/TetrisConsts.js
@@ -5,7 +5,12 @@ export const TickRate = 20;
 export const DropRate = 1;
 
 export const Tetrominoes = deepFreeze({
-  [TetrominoType.I]: [[CellType.I, CellType.I, CellType.I, CellType.I]],
+  [TetrominoType.I]: [
+    [CellType.Empty, CellType.Empty, CellType.Empty, CellType.Empty],
+    [CellType.I, CellType.I, CellType.I, CellType.I],
+    [CellType.Empty, CellType.Empty, CellType.Empty, CellType.Empty],
+    [CellType.Empty, CellType.Empty, CellType.Empty, CellType.Empty],
+  ],
   [TetrominoType.O]: [
     [CellType.O, CellType.O],
     [CellType.O, CellType.O],
@@ -13,22 +18,27 @@ export const Tetrominoes = deepFreeze({
   [TetrominoType.T]: [
     [CellType.Empty, CellType.T, CellType.Empty],
     [CellType.T, CellType.T, CellType.T],
+    [CellType.Empty, CellType.Empty, CellType.Empty],
   ],
   [TetrominoType.J]: [
     [CellType.J, CellType.Empty, CellType.Empty],
     [CellType.J, CellType.J, CellType.J],
+    [CellType.Empty, CellType.Empty, CellType.Empty],
   ],
   [TetrominoType.L]: [
     [CellType.Empty, CellType.Empty, CellType.L],
     [CellType.L, CellType.L, CellType.L],
+    [CellType.Empty, CellType.Empty, CellType.Empty],
   ],
   [TetrominoType.S]: [
     [CellType.Empty, CellType.S, CellType.S],
     [CellType.S, CellType.S, CellType.Empty],
+    [CellType.Empty, CellType.Empty, CellType.Empty],
   ],
   [TetrominoType.Z]: [
     [CellType.Z, CellType.Z, CellType.Empty],
     [CellType.Empty, CellType.Z, CellType.Z],
+    [CellType.Empty, CellType.Empty, CellType.Empty],
   ],
 });
 

--- a/todo.md
+++ b/todo.md
@@ -1,1 +1,0 @@
-totest: go in wrong room, go home, go in new room as admin, go back twice with arrow back, bug should display the admin panel when not one

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,1 @@
+totest: go in wrong room, go home, go in new room as admin, go back twice with arrow back, bug should display the admin panel when not one


### PR DESCRIPTION
Closes #39 
Due to some black magic adding empty rows/cols to the tetromino definitions makes them rotate correctly xd
It's surely cause the rotation method rotates from the center